### PR TITLE
upgrade to wildcat-net v0.1.1

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 gtest/cci.20210126
-wildcat-net/0.1.0@ross/stable
+wildcat-net/0.1.1@ross/stable
 openssl/3.0.2
 
 [generators]

--- a/include/wildcat/ws/client.hpp
+++ b/include/wildcat/ws/client.hpp
@@ -416,7 +416,7 @@ namespace wildcat::ws {
         }
 
         /// Connects to the endpoint and initiates the web socket handshake
-        bool connect(const std::string &host, const std::string &port) {
+        bool connect(const std::string &host, std::uint16_t port) {
             try {
                 stream_->connect(host, port);
                 const auto hostName = hostName_.empty() ? host : hostName_;


### PR DESCRIPTION
- supports using port as uint16_t instead of string